### PR TITLE
Hotfix/add default as fallback to env (#4)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,9 +220,12 @@ pub trait Events {
 
 impl Cluster {
     pub fn new() -> Cluster {
-        let kubernetes_api_host: &str = &env::var("KUBERNETES_API_HOST").expect("KUBERNETES_API_HOST not set.");
-        let active_host = if kubernetes_api_host.len() > 0 { kubernetes_api_host } else { DEFAULT_HOST };
-        Cluster { host: Url::parse(active_host).unwrap() }
+        let environment_value: &str = &env::var("KUBERNETES_API_HOST").unwrap();
+        let kubernetes_api_host = match environment_value.len() > 0 {
+            true => environment_value,
+            false => DEFAULT_HOST,
+        };
+        Cluster { host: Url::parse(kubernetes_api_host).unwrap() }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,11 +220,7 @@ pub trait Events {
 
 impl Cluster {
     pub fn new() -> Cluster {
-        let environment_value: &str = &env::var("KUBERNETES_API_HOST").unwrap();
-        let kubernetes_api_host = match environment_value.len() > 0 {
-            true => environment_value,
-            false => DEFAULT_HOST,
-        };
+        let kubernetes_api_host: &str = &env::var("KUBERNETES_API_HOST").unwrap_or(DEFAULT_HOST.to_string());
         Cluster { host: Url::parse(kubernetes_api_host).unwrap() }
     }
 }


### PR DESCRIPTION
**Fix**
- Need to unwrap ENV, it still will produce runtime error.
- Using `match` seems more readable and rust like. (Looking for advice on the issue: https://codereview.stackexchange.com/q/179878/13425)